### PR TITLE
#4 - 투표 도메인 구현

### DIFF
--- a/src/main/java/com/capstone/pick/domain/Hashtag.java
+++ b/src/main/java/com/capstone/pick/domain/Hashtag.java
@@ -1,0 +1,19 @@
+package com.capstone.pick.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Hashtag {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "hashtag_id")
+    private Long id; // 해시태그 id
+
+    @Column(length = 50)
+    private String content; // 해시태그 본문
+}

--- a/src/main/java/com/capstone/pick/domain/Hashtag.java
+++ b/src/main/java/com/capstone/pick/domain/Hashtag.java
@@ -1,12 +1,10 @@
 package com.capstone.pick.domain;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Getter
-@NoArgsConstructor
 @Entity
 public class Hashtag {
 
@@ -16,4 +14,14 @@ public class Hashtag {
 
     @Column(length = 50)
     private String content; // 해시태그 본문
+
+    protected Hashtag() {}
+
+    private Hashtag(String content) {
+        this.content = content;
+    }
+
+    public static Hashtag of(String content) {
+        return new Hashtag(content);
+    }
 }

--- a/src/main/java/com/capstone/pick/domain/Pick.java
+++ b/src/main/java/com/capstone/pick/domain/Pick.java
@@ -1,12 +1,10 @@
 package com.capstone.pick.domain;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Getter
-@NoArgsConstructor
 @Entity
 public class Pick {
 
@@ -21,4 +19,15 @@ public class Pick {
     @ManyToOne(optional = false)
     @JoinColumn(name = "vote_option_id")
     private VoteOption voteOption; // 선택지 id
+
+    protected Pick() {}
+
+    private Pick(User user, VoteOption voteOption) {
+        this.user = user;
+        this.voteOption = voteOption;
+    }
+
+    public static Pick of(User user, VoteOption voteOption) {
+        return new Pick(user, voteOption);
+    }
 }

--- a/src/main/java/com/capstone/pick/domain/Pick.java
+++ b/src/main/java/com/capstone/pick/domain/Pick.java
@@ -1,0 +1,24 @@
+package com.capstone.pick.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Pick {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pick_id")
+    private Long id; // 투표 선택지 id
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user; // 유저 id
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "vote_option_id")
+    private VoteOption voteOption; // 선택지 id
+}

--- a/src/main/java/com/capstone/pick/domain/User.java
+++ b/src/main/java/com/capstone/pick/domain/User.java
@@ -1,0 +1,47 @@
+package com.capstone.pick.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class User {
+
+    @Id @Column(length = 50, name = "user_id")
+    private String userId; // 유저 Id
+
+    @Column(nullable = false)
+    private String userPassword; // 유저 암호
+
+    @Column(length = 100)
+    private String email; // 이메일
+
+    @Column(length = 100)
+    private String nickname; // 닉네임
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime birthday; // 출생일시
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt; // 생성일시
+
+    private String memo; // 메모
+
+    /* TODO: 가입방식과 멤버십은 주요 기능이 완료된 후에
+         멤버십과 소셜 로그인 기능을 구현한 후에 진행하도록 한다.
+    private String provider; // 가입방식
+    private String membership; // 멤버십
+    */
+
+}

--- a/src/main/java/com/capstone/pick/domain/User.java
+++ b/src/main/java/com/capstone/pick/domain/User.java
@@ -1,7 +1,6 @@
 package com.capstone.pick.domain;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -11,7 +10,6 @@ import javax.persistence.Id;
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
 @Entity
 public class User {
 
@@ -44,4 +42,18 @@ public class User {
     private String membership; // 멤버십
     */
 
+    protected User() {}
+
+    private User(String userId, String userPassword, String email, String nickname, LocalDateTime birthday, String memo) {
+        this.userId = userId;
+        this.userPassword = userPassword;
+        this.email = email;
+        this.nickname = nickname;
+        this.birthday = birthday;
+        this.memo = memo;
+    }
+
+    public static User of(String userId, String userPassword, String email, String nickname, LocalDateTime birthday, String memo) {
+        return new User(userId, userPassword, email, nickname, birthday, memo);
+    }
 }

--- a/src/main/java/com/capstone/pick/domain/Vote.java
+++ b/src/main/java/com/capstone/pick/domain/Vote.java
@@ -1,0 +1,51 @@
+package com.capstone.pick.domain;
+
+import com.capstone.pick.domain.constant.Category;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Vote {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vote_id")
+    private Long id; // 투표 게시글 id
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user; // 유저 정보 (id)
+
+    @Column(length = 100)
+    private String title; // 제목
+
+    @Column(length = 100)
+    private String content; // 내용
+
+    @Enumerated(EnumType.STRING)
+    private Category category; // 카테고리
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime expiredAt; // 종료일시
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createAt; // 생성일시
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt; // 수정일시
+
+    private boolean isMultiPick; // 다중선택가능여부
+
+}

--- a/src/main/java/com/capstone/pick/domain/Vote.java
+++ b/src/main/java/com/capstone/pick/domain/Vote.java
@@ -2,7 +2,6 @@ package com.capstone.pick.domain;
 
 import com.capstone.pick.domain.constant.Category;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -12,7 +11,6 @@ import java.time.LocalDateTime;
 
 
 @Getter
-@NoArgsConstructor
 @Entity
 public class Vote {
 
@@ -48,4 +46,18 @@ public class Vote {
 
     private boolean isMultiPick; // 다중선택가능여부
 
+    protected Vote() {}
+
+    private Vote(User user, String title, String content, Category category, LocalDateTime expiredAt, boolean isMultiPick) {
+        this.user = user;
+        this.title = title;
+        this.content = content;
+        this.category = category;
+        this.expiredAt = expiredAt;
+        this.isMultiPick = isMultiPick;
+    }
+
+    public static Vote of(User user, String title, String content, Category category, LocalDateTime expiredAt, boolean isMultiPick) {
+        return new Vote(user, title, content, category, expiredAt, isMultiPick);
+    }
 }

--- a/src/main/java/com/capstone/pick/domain/VoteComment.java
+++ b/src/main/java/com/capstone/pick/domain/VoteComment.java
@@ -1,0 +1,41 @@
+package com.capstone.pick.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class VoteComment {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vote_comment_id")
+    private Long id; // 투표 댓글 id
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "vote_id")
+    private Vote vote;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(length = 2000)
+    private String content;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createAt;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/capstone/pick/domain/VoteComment.java
+++ b/src/main/java/com/capstone/pick/domain/VoteComment.java
@@ -1,7 +1,6 @@
 package com.capstone.pick.domain;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -10,7 +9,6 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
 @Entity
 public class VoteComment {
 
@@ -38,4 +36,16 @@ public class VoteComment {
     @LastModifiedDate
     @Column(nullable = false)
     private LocalDateTime modifiedAt;
+
+    protected VoteComment() {}
+
+    private VoteComment(Vote vote, User user, String content) {
+        this.vote = vote;
+        this.user = user;
+        this.content = content;
+    }
+
+    public static VoteComment of(Vote vote, User user, String content) {
+        return new VoteComment(vote, user, content);
+    }
 }

--- a/src/main/java/com/capstone/pick/domain/VoteHashtag.java
+++ b/src/main/java/com/capstone/pick/domain/VoteHashtag.java
@@ -1,0 +1,23 @@
+package com.capstone.pick.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class VoteHashtag {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 투표 해시태그 id
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "vote_id")
+    private Vote vote; // 투표 게시글 id
+
+    @ManyToOne
+    @JoinColumn(name = "hashtag_id")
+    private Hashtag hashtag; // 해시태그 id
+}

--- a/src/main/java/com/capstone/pick/domain/VoteHashtag.java
+++ b/src/main/java/com/capstone/pick/domain/VoteHashtag.java
@@ -1,12 +1,10 @@
 package com.capstone.pick.domain;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Getter
-@NoArgsConstructor
 @Entity
 public class VoteHashtag {
 
@@ -20,4 +18,15 @@ public class VoteHashtag {
     @ManyToOne
     @JoinColumn(name = "hashtag_id")
     private Hashtag hashtag; // 해시태그 id
+
+    protected VoteHashtag() {}
+
+    private VoteHashtag(Vote vote, Hashtag hashtag) {
+        this.vote = vote;
+        this.hashtag = hashtag;
+    }
+
+    public static VoteHashtag of(Vote vote, Hashtag hashtag) {
+        return new VoteHashtag(vote, hashtag);
+    }
 }

--- a/src/main/java/com/capstone/pick/domain/VoteOption.java
+++ b/src/main/java/com/capstone/pick/domain/VoteOption.java
@@ -1,12 +1,10 @@
 package com.capstone.pick.domain;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Getter
-@NoArgsConstructor
 @Entity
 public class VoteOption {
 
@@ -24,4 +22,15 @@ public class VoteOption {
     @Column(length = 255)
     private String imageLink; // 이미지 링크
 
+    protected VoteOption() {}
+
+    private VoteOption(Vote vote, String content, String imageLink) {
+        this.vote = vote;
+        this.content = content;
+        this.imageLink = imageLink;
+    }
+
+    public static VoteOption of(Vote vote, String content, String imageLink) {
+        return new VoteOption(vote, content, imageLink);
+    }
 }

--- a/src/main/java/com/capstone/pick/domain/VoteOption.java
+++ b/src/main/java/com/capstone/pick/domain/VoteOption.java
@@ -1,0 +1,27 @@
+package com.capstone.pick.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class VoteOption {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vote_option_id")
+    private Long id; // 투표 선택지 id
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "vote_id")
+    private Vote vote; // 투표 게시글 id
+
+    @Column(length = 255)
+    private String content; // 본문
+
+    @Column(length = 255)
+    private String imageLink; // 이미지 링크
+
+}

--- a/src/main/java/com/capstone/pick/domain/constant/Category.java
+++ b/src/main/java/com/capstone/pick/domain/constant/Category.java
@@ -1,0 +1,6 @@
+package com.capstone.pick.domain.constant;
+
+// TODO : 투표 게시판에 적용할 카테고리의 종류는 회의를 통해서 진행하도록 한다.
+public enum Category {
+
+}


### PR DESCRIPTION
회의를 통해 작성된 E-R 다이어그램을 바탕으로 우리 서비스에서 사용될 도메인을 구현하였다.

* 사용자 도메인 : 가입 방식과 멤버십은 주요 기능 구현이 완료된 후레 멤버십 정책과 소셜 로그인 기능을 구현하는 과정에서 진행하도록 TODO 로 남겨두었다.
* 투표 게시글 도메인 : 투표 게시글의 카테고리의 종류는 아직 결정되지 않았기 때문에 빈칸으로 되어있다. 추후 회의를 통해 결정하도록 한다.
* 해시태그 도메인
* 투표 게시글 댓글 도메인
* 투표 선택지 도메인
* 투표 해시태그 도메인

This closes #4 