### PR TITLE
#8 - 리펙토링 : 생성자 생성 패턴 변경

### DIFF
--- a/src/main/java/com/capstone/pick/domain/Hashtag.java
+++ b/src/main/java/com/capstone/pick/domain/Hashtag.java
@@ -1,10 +1,16 @@
 package com.capstone.pick.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 public class Hashtag {
 
@@ -15,13 +21,4 @@ public class Hashtag {
     @Column(length = 50)
     private String content; // 해시태그 본문
 
-    protected Hashtag() {}
-
-    private Hashtag(String content) {
-        this.content = content;
-    }
-
-    public static Hashtag of(String content) {
-        return new Hashtag(content);
-    }
 }

--- a/src/main/java/com/capstone/pick/domain/Pick.java
+++ b/src/main/java/com/capstone/pick/domain/Pick.java
@@ -1,10 +1,16 @@
 package com.capstone.pick.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 public class Pick {
 
@@ -20,14 +26,4 @@ public class Pick {
     @JoinColumn(name = "vote_option_id")
     private VoteOption voteOption; // 선택지 id
 
-    protected Pick() {}
-
-    private Pick(User user, VoteOption voteOption) {
-        this.user = user;
-        this.voteOption = voteOption;
-    }
-
-    public static Pick of(User user, VoteOption voteOption) {
-        return new Pick(user, voteOption);
-    }
 }

--- a/src/main/java/com/capstone/pick/domain/User.java
+++ b/src/main/java/com/capstone/pick/domain/User.java
@@ -1,6 +1,9 @@
 package com.capstone.pick.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -10,6 +13,9 @@ import javax.persistence.Id;
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 public class User {
 
@@ -41,19 +47,5 @@ public class User {
     private String provider; // 가입방식
     private String membership; // 멤버십
     */
-
-    protected User() {}
-
-    private User(String userId, String userPassword, String email, String nickname, LocalDateTime birthday, String memo) {
-        this.userId = userId;
-        this.userPassword = userPassword;
-        this.email = email;
-        this.nickname = nickname;
-        this.birthday = birthday;
-        this.memo = memo;
-    }
-
-    public static User of(String userId, String userPassword, String email, String nickname, LocalDateTime birthday, String memo) {
-        return new User(userId, userPassword, email, nickname, birthday, memo);
-    }
+    
 }

--- a/src/main/java/com/capstone/pick/domain/Vote.java
+++ b/src/main/java/com/capstone/pick/domain/Vote.java
@@ -1,7 +1,10 @@
 package com.capstone.pick.domain;
 
 import com.capstone.pick.domain.constant.Category;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -11,6 +14,9 @@ import java.time.LocalDateTime;
 
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 public class Vote {
 
@@ -46,18 +52,4 @@ public class Vote {
 
     private boolean isMultiPick; // 다중선택가능여부
 
-    protected Vote() {}
-
-    private Vote(User user, String title, String content, Category category, LocalDateTime expiredAt, boolean isMultiPick) {
-        this.user = user;
-        this.title = title;
-        this.content = content;
-        this.category = category;
-        this.expiredAt = expiredAt;
-        this.isMultiPick = isMultiPick;
-    }
-
-    public static Vote of(User user, String title, String content, Category category, LocalDateTime expiredAt, boolean isMultiPick) {
-        return new Vote(user, title, content, category, expiredAt, isMultiPick);
-    }
 }

--- a/src/main/java/com/capstone/pick/domain/VoteComment.java
+++ b/src/main/java/com/capstone/pick/domain/VoteComment.java
@@ -1,6 +1,9 @@
 package com.capstone.pick.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -9,6 +12,9 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 public class VoteComment {
 
@@ -37,15 +43,4 @@ public class VoteComment {
     @Column(nullable = false)
     private LocalDateTime modifiedAt;
 
-    protected VoteComment() {}
-
-    private VoteComment(Vote vote, User user, String content) {
-        this.vote = vote;
-        this.user = user;
-        this.content = content;
-    }
-
-    public static VoteComment of(Vote vote, User user, String content) {
-        return new VoteComment(vote, user, content);
-    }
 }

--- a/src/main/java/com/capstone/pick/domain/VoteHashtag.java
+++ b/src/main/java/com/capstone/pick/domain/VoteHashtag.java
@@ -1,10 +1,16 @@
 package com.capstone.pick.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 public class VoteHashtag {
 
@@ -19,14 +25,4 @@ public class VoteHashtag {
     @JoinColumn(name = "hashtag_id")
     private Hashtag hashtag; // 해시태그 id
 
-    protected VoteHashtag() {}
-
-    private VoteHashtag(Vote vote, Hashtag hashtag) {
-        this.vote = vote;
-        this.hashtag = hashtag;
-    }
-
-    public static VoteHashtag of(Vote vote, Hashtag hashtag) {
-        return new VoteHashtag(vote, hashtag);
-    }
 }

--- a/src/main/java/com/capstone/pick/domain/VoteOption.java
+++ b/src/main/java/com/capstone/pick/domain/VoteOption.java
@@ -1,10 +1,16 @@
 package com.capstone.pick.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 public class VoteOption {
 
@@ -22,15 +28,4 @@ public class VoteOption {
     @Column(length = 255)
     private String imageLink; // 이미지 링크
 
-    protected VoteOption() {}
-
-    private VoteOption(Vote vote, String content, String imageLink) {
-        this.vote = vote;
-        this.content = content;
-        this.imageLink = imageLink;
-    }
-
-    public static VoteOption of(Vote vote, String content, String imageLink) {
-        return new VoteOption(vote, content, imageLink);
-    }
 }


### PR DESCRIPTION
기존의 코드는 'protect' 와 'private' 접근 제한자가 적용된 생성자를 호출하는 static of 메소드를 통하여 생성자에 접근하는 패턴을 사용하였지만, 생성자 호출 시에 인자가 많은 엔티티도 존재하기 때문에 팀원들의 의견을 반영하여 'Builder' 패턴을 적용하였다.

This closes #8 