### PR TITLE
#15 - 투표 댓글 상세페이지 뷰 구현

### DIFF
--- a/src/main/java/com/capstone/pick/controller/VoteCommentsController.java
+++ b/src/main/java/com/capstone/pick/controller/VoteCommentsController.java
@@ -3,6 +3,13 @@ package com.capstone.pick.controller;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
+
+/**
+ * TODO : 댓글 상세 페이지는 각 투표 게시글에 연결되는 것이기 때문에
+ *         추후에 게시글 구현이 완료되면 각 게시글에 연결하도록 하며,
+ *         추가로 테스트 케이스도 수정한다. -> @PathVariable 로 연결;
+ */
+
 @Controller
 public class VoteCommentsController {
 

--- a/src/main/java/com/capstone/pick/controller/VoteCommentsController.java
+++ b/src/main/java/com/capstone/pick/controller/VoteCommentsController.java
@@ -1,0 +1,13 @@
+package com.capstone.pick.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class VoteCommentsController {
+
+    @GetMapping("/comments")
+    public String readComments() {
+        return "page/comments";
+    }
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -223,3 +223,31 @@
 .hover-shadow-white:hover {
     box-shadow: 0px 0px 5px 5px white;
 }
+
+.custom-form {
+    position: relative;
+    width: 300px;
+}
+.custom-form-input {
+    width: 100%;
+    border: 1px solid #ccc;
+    border-radius: 100px;
+    padding: 10px 100px 10px 20px;
+    line-height: 1;
+    box-sizing: border-box;
+    outline: none;
+}
+.custom-botton {
+    position: absolute;
+    right: 3px;
+    top: 3px;
+    bottom: 3px;
+    border: 0;
+    background: #7A57F6;
+    color: #fff;
+    outline: none;
+    margin: 0;
+    padding: 0 10px;
+    border-radius: 100px;
+    z-index: 2;
+}

--- a/src/main/resources/templates/page/comments.html
+++ b/src/main/resources/templates/page/comments.html
@@ -20,12 +20,54 @@
     <script type="text/javascript" src="js/script.js"></script>
 </head>
 <body>
-<div class="timeline-background">
-    <header class="d-flex flex-wrap align-items-center justify-content-center py-3 mb-4 border-bottom">
-        <div>
-            <span class="nav-link px-2 link-dark">comments</span>
+<div class="timeline-background h-100">
+    <header class="d-flex flex-wrap align-items-center py-3 border-bottom">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
+        </svg>
+        <div class="my-0 mx-auto">
+            <h4 class="nav-link px-2 link-dark" style="margin-bottom: 0;">comments</h4>
         </div>
     </header>
+    <div class="mb-3">
+        <div class="d-flex text-muted pl-3 pt-3 border-bottom">
+            <svg class="bd-placeholder-img flex-shrink-0 me-2 rounded-circle" width="32" height="32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: 32x32" preserveAspectRatio="xMidYMid slice" focusable="false">
+                <title>Placeholder</title>
+                <rect width="100%" height="100%" fill="#CA5151"></rect>
+            </svg>
+            <p class="pb-3 mb-0 small lh-sm">
+                <strong class="d-block text-dark mb-1">picker3</strong>
+                행궁동 OO 예쁘던데 가보세요
+            </p>
+        </div>
+
+        <div class="d-flex text-muted pl-3 pt-3 border-bottom">
+            <svg class="bd-placeholder-img flex-shrink-0 me-2 rounded-circle" width="32" height="32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: 32x32" preserveAspectRatio="xMidYMid slice" focusable="false">
+                <title>Placeholder</title>
+                <rect width="100%" height="100%" fill="#51CAAD"></rect>
+            </svg>
+            <p class="pb-3 mb-0 small lh-sm">
+                <strong class="d-block text-dark mb-1">picker5</strong>
+                수원역 고고고
+            </p>
+        </div>
+    </div>
+    <footer class="d-flex align-items-center py-3 ml-3 my-2 fixed-bottom">
+        <svg class="bd-placeholder-img flex-shrink-0 me-2 rounded-circle" width="40" height="40" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: 32x32" preserveAspectRatio="xMidYMid slice" focusable="false">
+            <title>Placeholder</title>
+            <rect width="100%" height="100%" fill="#F07F7F"></rect>
+        </svg>
+<!--        <form class="p-2 vw-100">-->
+<!--            <input type="text" class="form-control" placeholder="댓글 달기..." required>-->
+<!--            <span class="input-group">-->
+<!--                <button class="btn" type="submit" value="게시" ></button>-->
+<!--            </span>-->
+<!--        </form>-->
+        <form class="custom-form vw-100">
+            <input type="text" class="custom-form-input" placeholder="댓글 달기..." required>
+            <button class="custom-botton" type="submit">게시</button>
+        </form>
+    </footer>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/page/comments.html
+++ b/src/main/resources/templates/page/comments.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" class="h-100">
+<head>
+    <meta charset="UTF-8">
+    <title>Pickgether</title>
+    <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="css/bootstrap.min2.css">
+    <link rel="stylesheet" type="text/css" href="css/style.css">
+    <link rel="stylesheet" type="text/css" href="css/style2.css">
+
+    <!-- 픽게더 폰트 -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Oleo+Script+Swash+Caps&display=swap" rel="stylesheet">
+
+
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+            integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+            crossorigin="anonymous"></script>
+    <script type="text/javascript" src="js/script.js"></script>
+</head>
+<body>
+<div class="timeline-background">
+    <header class="d-flex flex-wrap align-items-center justify-content-center py-3 mb-4 border-bottom">
+        <div>
+            <span class="nav-link px-2 link-dark">comments</span>
+        </div>
+    </header>
+</div>
+</body>
+</html>

--- a/src/test/java/com/capstone/pick/controller/VoteCommentsControllerTest.java
+++ b/src/test/java/com/capstone/pick/controller/VoteCommentsControllerTest.java
@@ -1,0 +1,34 @@
+package com.capstone.pick.controller;
+
+import com.capstone.pick.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 컨트롤러 - 댓글")
+@Import(SecurityConfig.class)
+@WebMvcTest(VoteCommentsController.class)
+class VoteCommentsControllerTest {
+
+    private final MockMvc mvc;
+
+    public VoteCommentsControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[Comment][GET][/comments] 댓글 상세보기 페이지")
+    @Test
+    void 댓글상세보기_뷰_엔드포인트_테스트() throws Exception {
+        mvc.perform(get("/comments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("page/comments"));
+    }
+}


### PR DESCRIPTION
투표 댓글 상세페이지 뷰를 구현하였다.

실제 각 투표 댓글 상세페이지는 각 게시글에 연결되어야하지만,
게시글 기능 구현보다 투표 상세페이지 뷰 구현이 빨라 "/comments" 엔드포인트로 설정하였다.

이후에 게시글 기능이 구현되면 각 게시글에 댓글 페이지를 연결하면 댓글 컨트롤러와 컨트롤러 테스트를 수정해야한다.

This closes #15 