### PR TITLE
#14 - 투표 게시글 테스트 케이스 추가 작성

### DIFF
--- a/src/main/java/com/capstone/pick/PickApplication.java
+++ b/src/main/java/com/capstone/pick/PickApplication.java
@@ -2,7 +2,6 @@ package com.capstone.pick;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
 @SpringBootApplication
 public class PickApplication {

--- a/src/main/java/com/capstone/pick/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/pick/config/SecurityConfig.java
@@ -29,7 +29,6 @@ public class SecurityConfig {
                 .rememberMe().and()
                 .authorizeRequests(auth -> auth
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                        .mvcMatchers(HttpMethod.GET, "/", "/timeLine").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin()

--- a/src/main/java/com/capstone/pick/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/pick/config/SecurityConfig.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;

--- a/src/main/java/com/capstone/pick/controller/VoteCommentsController.java
+++ b/src/main/java/com/capstone/pick/controller/VoteCommentsController.java
@@ -22,7 +22,6 @@ public class VoteCommentsController {
 
     private final VoteCommentService voteCommentService;
 
-
     /**
      * 댓글을 조회한다
      * @param voteId 게시글 id
@@ -34,7 +33,6 @@ public class VoteCommentsController {
         model.addAttribute("comments",comments);
         return "page/comments";
     }
-
 
     /**
      * 댓글을 작성한다
@@ -50,7 +48,6 @@ public class VoteCommentsController {
         voteCommentService.saveComment(commentForm.toDto(votePrincipal.toDto()));
         return "redirect:/" + voteId + "/comments";
     }
-
 
     /**
      * 댓글을 수정한다
@@ -69,7 +66,6 @@ public class VoteCommentsController {
         return "redirect:/" + voteId + "/comments";
     }
 
-
     /**
      * 댓글을 삭제한다
      * @param votePrincipal 사용자
@@ -84,6 +80,4 @@ public class VoteCommentsController {
         voteCommentService.deleteComment(commentId, votePrincipal.toDto().getUserId());
         return "redirect:/" + voteId + "/comments";
     }
-
-
 }

--- a/src/main/java/com/capstone/pick/controller/VoteController.java
+++ b/src/main/java/com/capstone/pick/controller/VoteController.java
@@ -22,6 +22,11 @@ public class VoteController {
 
     private final VoteService voteService;
 
+    @GetMapping("/")
+    public String home() {
+        return "redirect:/timeline";
+    }
+
     @GetMapping("/timeline")
     public String timeLine(Model model) {
         List<VoteDto> votes = voteService.findAllVotes();

--- a/src/main/java/com/capstone/pick/controller/form/VoteForm.java
+++ b/src/main/java/com/capstone/pick/controller/form/VoteForm.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-
 @Getter
 @Setter
 @Builder

--- a/src/main/java/com/capstone/pick/domain/Vote.java
+++ b/src/main/java/com/capstone/pick/domain/Vote.java
@@ -19,7 +19,6 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/capstone/pick/domain/VoteOption.java
+++ b/src/main/java/com/capstone/pick/domain/VoteOption.java
@@ -27,5 +27,4 @@ public class VoteOption {
 
     @Column(length = 255)
     private String imageLink; // 이미지 링크
-
 }

--- a/src/main/java/com/capstone/pick/exeption/UserMismatchException.java
+++ b/src/main/java/com/capstone/pick/exeption/UserMismatchException.java
@@ -1,7 +1,5 @@
 package com.capstone.pick.exeption;
 
-import java.io.IOException;
-
 public class UserMismatchException extends Exception {
 
 }

--- a/src/main/java/com/capstone/pick/handler/ErrorResponse.java
+++ b/src/main/java/com/capstone/pick/handler/ErrorResponse.java
@@ -3,7 +3,6 @@ package com.capstone.pick.handler;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-
 @Getter
 @AllArgsConstructor
 public class ErrorResponse {

--- a/src/main/java/com/capstone/pick/handler/VoteCommentsExceptionHandler.java
+++ b/src/main/java/com/capstone/pick/handler/VoteCommentsExceptionHandler.java
@@ -2,7 +2,6 @@ package com.capstone.pick.handler;
 
 import com.capstone.pick.controller.VoteCommentsController;
 import com.capstone.pick.exeption.UserMismatchException;
-import com.capstone.pick.handler.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -10,7 +9,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice(assignableTypes = VoteCommentsController.class)
 public class VoteCommentsExceptionHandler {
-
 
     @ExceptionHandler(UserMismatchException.class)
     public ResponseEntity<ErrorResponse> UserMismatchException() {

--- a/src/test/java/com/capstone/pick/controller/LoginControllerTest.java
+++ b/src/test/java/com/capstone/pick/controller/LoginControllerTest.java
@@ -36,6 +36,4 @@ class LoginControllerTest {
                 .andExpect(view().name("/page/login")); // 리턴하는 뷰 이름은 무엇인가?
                 //.andExpect(model().attributeExists("")); // 뷰에 애트리뷰트가 존재하는가?
     }
-
-
 }

--- a/src/test/java/com/capstone/pick/controller/VoteCommentsControllerTest.java
+++ b/src/test/java/com/capstone/pick/controller/VoteCommentsControllerTest.java
@@ -28,7 +28,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("View 컨트롤러 - 댓글")
 @Import(TestSecurityConfig.class)
 @WebMvcTest(VoteCommentsController.class)
-@WithMockUser
 class VoteCommentsControllerTest {
 
     private final MockMvc mvc;
@@ -40,7 +39,23 @@ class VoteCommentsControllerTest {
         this.mvc = mvc;
     }
 
-    @DisplayName("[Comment][GET][/{voteId}/comments] 댓글 상세보기 페이지")
+    @DisplayName("[Comment][GET][/{voteId}/comments] 댓글 상세보기 페이지 - 인증이 없을 땐 로그인 페이지로 이동")
+    @Test
+    void noLoginUser_readComments() throws Exception {
+        // given
+        long voteId = 1L;
+
+        // when
+        mvc.perform(get("/" + voteId + "/comments"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+
+        // then
+        then(voteCommentService).shouldHaveNoInteractions();
+    }
+
+    @WithMockUser
+    @DisplayName("[Comment][GET][/{voteId}/comments] 댓글 상세보기 페이지 - 인증된 사용자")
     @Test
     void 댓글상세보기_뷰_엔드포인트_테스트() throws Exception {
         long voteId = 1L;

--- a/src/test/java/com/capstone/pick/controller/VoteControllerTest.java
+++ b/src/test/java/com/capstone/pick/controller/VoteControllerTest.java
@@ -4,7 +4,9 @@ import com.capstone.pick.config.TestSecurityConfig;
 import com.capstone.pick.controller.form.VoteForm;
 import com.capstone.pick.controller.form.VoteOptionFormDto;
 import com.capstone.pick.domain.constant.Category;
+import com.capstone.pick.domain.constant.DisplayRange;
 import com.capstone.pick.dto.HashtagDto;
+import com.capstone.pick.dto.UserDto;
 import com.capstone.pick.dto.VoteDto;
 import com.capstone.pick.dto.VoteOptionDto;
 import com.capstone.pick.service.VoteService;
@@ -17,6 +19,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -24,6 +27,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -44,9 +48,27 @@ class VoteControllerTest {
         this.mvc = mvc;
     }
 
+    @WithUserDetails(value = "user", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("[view][GET] 홈페이지 - 정상 호출, 인증된 사용자")
+    @Test
+    void home() throws Exception {
+        mvc.perform(get("/"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/timeline"))
+                .andExpect(redirectedUrl("/timeline"));
+    }
+
+    @DisplayName("[view][GET] 홈페이지 - 인증이 없을 땐 로그인 페이지로 이동")
+    @Test
+    void noLoginUser_home() throws Exception {
+        mvc.perform(get("/"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
     // TODO : 타임라인 조회의 경우 추후에 정렬과 페이징이 적용되면 테스트를 수정 해야한다.
     @WithUserDetails(value = "user", setupBefore = TestExecutionEvent.TEST_EXECUTION)
-    @DisplayName("[view][GET] 투표 게시글 조회 - 정상 호출")
+    @DisplayName("[view][GET] 투표 게시글 조회 - 정상 호출, 인증된 사용자")
     @Test
     void timeLine() throws Exception {
         // given
@@ -59,6 +81,18 @@ class VoteControllerTest {
                 .andExpect(model().attributeExists("votes"));
 
         // then
+    }
+
+    @DisplayName("[view][GET] 투표 게시글 조회 - 인증이 없을 땐 로그인 페이지로 이동")
+    @Test
+    void noLoginUser_timeline() throws Exception {
+        // when
+        mvc.perform(get("/timeline"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+
+        // when
+        then(voteService).shouldHaveNoInteractions();
     }
 
     @WithUserDetails(value = "user", setupBefore = TestExecutionEvent.TEST_EXECUTION)
@@ -89,10 +123,69 @@ class VoteControllerTest {
         then(voteService).should().saveVote(any(VoteDto.class), Mockito.<VoteOptionDto>anyList(), Mockito.<HashtagDto>anyList());
     }
 
+    @DisplayName("[view][GET] 투표 게시글 수정 페이지 - 인증이 없을 땐 로그인 페이지로 이동")
+    @Test
+    void noLoginUser_editVote() throws Exception {
+        // given
+        long voteId = 1L;
+
+        // when & then
+        mvc.perform(get("/" + voteId + "/edit"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+        then(voteService).shouldHaveNoInteractions();
+    }
+
+    @WithMockUser
+    @DisplayName("[view][GET] 투표 게시글 수정 페이지 - 정상 호출, 인증된 사용자")
+    @Test
+    void editVote_GET() throws Exception {
+        // given
+        long voteId = 1L;
+
+        UserDto userDto = UserDto.builder()
+                .userId("user")
+                .userPassword("password")
+                .email("email@email.com")
+                .nickname("nick")
+                .memo("memo")
+                .birthday(LocalDateTime.now())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        VoteDto voteDto = VoteDto.builder()
+                .userDto(userDto)
+                .title("title")
+                .content("new content")
+                .voteOptions(List.of(VoteOptionFormDto.builder().content("new option1").imageLink("/link/image1.png").build(),
+                        VoteOptionFormDto.builder().content("new option2").imageLink("/link/image2.png").build()))
+                .category(Category.WORRY)
+                .expiredAt(LocalDateTime.now().plusDays(5))
+                .createAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .isMultiPick(true)
+                .displayRange(DisplayRange.PUBLIC)
+                .build();
+
+        given(voteService.getVote(voteId)).willReturn(voteDto);
+
+        // when
+        mvc.perform(get("/" + voteId + "/edit"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("/page/editForm"))
+//                .andExpect(model().attribute("voteForm", voteForm))
+//                .andExpect(model().attribute("optionDtos", optionDtos))
+                .andExpect(model().attribute("voteDto", voteDto));
+
+        // then
+        then(voteService).should().getVote(voteId);
+    }
+
     @WithUserDetails(value = "user", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[view][POST] 투표 게시글 수정 - 정상 호출")
     @Test
-    void updateVote() throws Exception {
+    void editVote_POST() throws Exception {
         // given
         long voteId = 1L;
 


### PR DESCRIPTION
초기 개발 단계에서 구현 상황을 쉽게 파악하기 위해서 루트 페이지와 타임라인 페이지는 인증을 피하도록 설정하였다.
하지만, 이제 해당 서비스에 대한 어느정도의 구현이 자리를 잡았고, 테스트 케이스를 좀 더 상세하게 작성하기 위해서
루트 페이지와 타임라인 페이지도 인증이 필요하도록 수정하였다.

이에 대해서 모든 페이지에 대해서 인증된 사용자에 대한 테스트 케이스를 추가하였다.