### PR TITLE
#63 - 투표 게시글 & 선택지 & 댓글 함께 반환 구현

### DIFF
--- a/src/main/java/com/capstone/pick/controller/VoteController.java
+++ b/src/main/java/com/capstone/pick/controller/VoteController.java
@@ -55,7 +55,7 @@ public class VoteController {
                            @RequestParam(required = false, defaultValue = "LATEST") OrderCriteria orderBy,
                            @AuthenticationPrincipal VotePrincipal votePrincipal,
                            Model model) {
-        List<VoteWithOptionDto> votes = voteService.findSortedVotesByCategory(category, orderBy);
+        List<VoteOptionCommentDto> votes = voteService.findSortedVotesByCategory(category, orderBy);
         model.addAttribute("votes", votes);
         model.addAttribute("category", category);
         model.addAttribute("orderBy", orderBy);

--- a/src/main/java/com/capstone/pick/domain/Vote.java
+++ b/src/main/java/com/capstone/pick/domain/Vote.java
@@ -68,6 +68,10 @@ public class Vote {
     @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL)
     private List<VoteOption> voteOptions = new ArrayList<>();
 
+    @ToString.Exclude
+    @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL)
+    private List<VoteComment> voteComments = new ArrayList<>();
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/capstone/pick/dto/VoteOptionCommentDto.java
+++ b/src/main/java/com/capstone/pick/dto/VoteOptionCommentDto.java
@@ -1,0 +1,57 @@
+package com.capstone.pick.dto;
+
+import com.capstone.pick.domain.Vote;
+import com.capstone.pick.domain.constant.Category;
+import com.capstone.pick.domain.constant.DisplayRange;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoteOptionCommentDto {
+
+    private Long id;
+    private UserDto userDto;
+    private String title;
+    private String content;
+    private Category category;
+    private LocalDateTime expiredAt;
+    private LocalDateTime createAt;
+    private LocalDateTime modifiedAt;
+    private boolean isMultiPick;
+    private DisplayRange displayRange;
+    private List<VoteOptionDto> voteOptionDtos;
+    private CommentDto commentDto;
+
+    public static VoteOptionCommentDto from(Vote entity) {
+        return VoteOptionCommentDto.builder()
+                .id(entity.getId())
+                .userDto(UserDto.from(entity.getUser()))
+                .title(entity.getTitle())
+                .content(entity.getContent())
+                .category(entity.getCategory())
+                .expiredAt(entity.getExpiredAt())
+                .createAt(entity.getCreateAt())
+                .modifiedAt(entity.getModifiedAt())
+                .isMultiPick(entity.isMultiPick())
+                .voteOptionDtos(entity.getVoteOptions().stream()
+                        .map(VoteOptionDto::from).collect(Collectors.toList()))
+                .commentDto(insertCommand(entity))
+                .build();
+    }
+
+    private static CommentDto insertCommand(Vote vote) {
+        if(vote.getVoteComments() == null || vote.getVoteComments().isEmpty()) {
+            return null;
+        }
+        return CommentDto.from(vote.getVoteComments().get(0));
+    }
+}

--- a/src/main/java/com/capstone/pick/service/VoteService.java
+++ b/src/main/java/com/capstone/pick/service/VoteService.java
@@ -7,10 +7,7 @@ import com.capstone.pick.domain.VoteHashtag;
 import com.capstone.pick.domain.constant.Category;
 import com.capstone.pick.domain.constant.OrderCriteria;
 import com.capstone.pick.domain.constant.SearchType;
-import com.capstone.pick.dto.HashtagDto;
-import com.capstone.pick.dto.VoteDto;
-import com.capstone.pick.dto.VoteOptionDto;
-import com.capstone.pick.dto.VoteWithOptionDto;
+import com.capstone.pick.dto.*;
 import com.capstone.pick.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +41,7 @@ public class VoteService {
     }
 
     @Transactional(readOnly = true)
-    public List<VoteWithOptionDto> findSortedVotesByCategory(Category category, OrderCriteria orderBy) {
+    public List<VoteOptionCommentDto> findSortedVotesByCategory(Category category, OrderCriteria orderBy) {
         List<Vote> votes = new ArrayList<>();
         switch (orderBy) {
             case LATEST:
@@ -58,7 +55,7 @@ public class VoteService {
                         : voteRepository.findByCategoryOrderByPopular(category);
                 break;
         }
-        return votes.stream().map(VoteWithOptionDto::from).collect(Collectors.toList());
+        return votes.stream().map(VoteOptionCommentDto::from).collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/templates/page/timeLine.html
+++ b/src/main/resources/templates/page/timeLine.html
@@ -220,9 +220,10 @@
                 <img src="/images/avatar.jpg" style="height: 42px; width: 42px;"/>
             </div>
             <div>
-                <section style="float: left; padding-left: 10px; font-size: 15px;">
-                    <div><b>picker 3</b></div>
-                    <div>행궁동 ㅇㅇ 예쁘던데 가보세요</div>
+                <section style="float: left; padding-left: 10px; font-size: 15px; width:90%;">
+                    <div th:text="${vote.getCommentDto().getUserDto().getUserId()}" style="font-weight: bold; display:inline-block;">picker 3</div>
+                    <div style="display: inline-block; float: right; width: 80%; height: 20px;" th:onclick="'location.href=\'' + ${vote.getId()} + '/comments' + '\''"></div>
+                    <div th:text="${vote.getCommentDto().getContent()}" th:onclick="'location.href=\'' + ${vote.getId()} + '/comments' + '\''">행궁동 ㅇㅇ 예쁘던데 가보세요</div>
                 </section>
             </div>
         </section>

--- a/src/test/java/com/capstone/pick/service/VoteServiceTest.java
+++ b/src/test/java/com/capstone/pick/service/VoteServiceTest.java
@@ -112,10 +112,10 @@ public class VoteServiceTest {
         given(voteRepository.findByCategoryOrderByPopular(Category.FREE)).willReturn(List.of(vote2, vote1));
 
         // when
-        List<VoteWithOptionDto> All_LATEST = voteService.findSortedVotesByCategory(Category.ALL, OrderCriteria.LATEST);
-        List<VoteWithOptionDto> All_POPULAR = voteService.findSortedVotesByCategory(Category.ALL, OrderCriteria.POPULAR);
-        List<VoteWithOptionDto> FREE_LATEST = voteService.findSortedVotesByCategory(Category.FREE, OrderCriteria.LATEST);
-        List<VoteWithOptionDto> FREE_POPULAR = voteService.findSortedVotesByCategory(Category.FREE, OrderCriteria.POPULAR);
+        List<VoteOptionCommentDto> All_LATEST = voteService.findSortedVotesByCategory(Category.ALL, OrderCriteria.LATEST);
+        List<VoteOptionCommentDto> All_POPULAR = voteService.findSortedVotesByCategory(Category.ALL, OrderCriteria.POPULAR);
+        List<VoteOptionCommentDto> FREE_LATEST = voteService.findSortedVotesByCategory(Category.FREE, OrderCriteria.LATEST);
+        List<VoteOptionCommentDto> FREE_POPULAR = voteService.findSortedVotesByCategory(Category.FREE, OrderCriteria.POPULAR);
 
         // then
         assertThat(All_LATEST.get(0))


### PR DESCRIPTION
현재 타임라인 뷰에서는 각 투표 게시글에 대한 댓글까지도 함께 나타나기 때문에 투표 게시글을 반환할 때 하나의 댓글도 함께 반환되도록 DTO 를 새롭게 구현하였다.
기존 DTO 를 그대로 유지하는 이유는 유저 프로필에서 조회되는 게시글의 경우는 댓글이 함께 반환되지 않게 하도록 하기 위해서이다.
추가적으로 관련된 테스트 코드와 타임라인도 간단하게 수정하였다.

This closes #63 