### PR TITLE
#79 - Redis 적용을 통한 성능 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
 	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+
+	implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.2'
+
 	// 소셜로그인
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 

--- a/src/main/java/com/capstone/pick/config/CustomUserDetailsService.java
+++ b/src/main/java/com/capstone/pick/config/CustomUserDetailsService.java
@@ -3,8 +3,10 @@ package com.capstone.pick.config;
 import com.capstone.pick.domain.User;
 import com.capstone.pick.dto.UserDto;
 import com.capstone.pick.exeption.DuplicatedUserException;
+import com.capstone.pick.repository.UserCacheRepository;
 import com.capstone.pick.repository.UserRepository;
 import com.capstone.pick.security.VotePrincipal;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -19,23 +21,30 @@ import java.util.Optional;
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
+    private final UserCacheRepository userCacheRepository;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        VotePrincipal votePrincipal = userRepository
-                .findById(username)
-                .map(UserDto::from)
-                .map(VotePrincipal::from)
-                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다 - username: " + username));
 
-        return votePrincipal;
+        UserDto user = null;
+        try {
+            user = userCacheRepository.getUser(username).orElseGet(() ->
+                    userRepository.findById(username)
+                            .map(UserDto::from)
+                            .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다 - username: " + username)));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        userCacheRepository.setUser(user);
+        return VotePrincipal.from(user);
     }
 
     public void save(UserDto userDto) throws DuplicatedUserException {
 
         Optional<User> user = userRepository.findById(userDto.getUserId());
 
-        if (user.isEmpty()){ // 동일한 아이디가 없다면 저장
+        if (user.isEmpty()) { // 동일한 아이디가 없다면 저장
             userRepository.save(userDto.toEntity());
         } else {  // 이미 아이디가 존재하면 예외처리
             throw new DuplicatedUserException();

--- a/src/main/java/com/capstone/pick/config/ObjectMapperConfig.java
+++ b/src/main/java/com/capstone/pick/config/ObjectMapperConfig.java
@@ -1,0 +1,19 @@
+package com.capstone.pick.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/capstone/pick/config/RedisConfig.java
+++ b/src/main/java/com/capstone/pick/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.capstone.pick.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/capstone/pick/dto/VoteOptionCommentDto.java
+++ b/src/main/java/com/capstone/pick/dto/VoteOptionCommentDto.java
@@ -7,7 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
+import org.springframework.data.redis.core.RedisHash;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@RedisHash("VOTE")
 public class VoteOptionCommentDto {
 
     private Long id;

--- a/src/main/java/com/capstone/pick/repository/UserCacheRepository.java
+++ b/src/main/java/com/capstone/pick/repository/UserCacheRepository.java
@@ -1,0 +1,47 @@
+package com.capstone.pick.repository;
+
+import com.capstone.pick.dto.UserDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class UserCacheRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final static Duration CACHE_TTL = Duration.ofDays(3);
+
+    public void setUser(UserDto user) {
+        try {
+            redisTemplate.opsForValue().set(getKey(user.getUserId()), serializeUserDto(user), CACHE_TTL);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+
+    public Optional<UserDto> getUser(String username) throws JsonProcessingException {
+        return Optional.ofNullable(deserializeUserDto(redisTemplate.opsForValue().get(getKey(username))));
+    }
+
+    private String getKey(String username) {
+        return "USER:" + username;
+    }
+
+    private String serializeUserDto(UserDto user) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(user);
+    }
+
+    private UserDto deserializeUserDto(String value) throws JsonProcessingException {
+        if(value == null) return null;
+        return objectMapper.readValue(value, UserDto.class);
+    }
+}

--- a/src/main/java/com/capstone/pick/repository/VoteRedisRepository.java
+++ b/src/main/java/com/capstone/pick/repository/VoteRedisRepository.java
@@ -1,0 +1,12 @@
+package com.capstone.pick.repository;
+
+import com.capstone.pick.domain.constant.Category;
+import com.capstone.pick.dto.VoteOptionCommentDto;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface VoteRedisRepository extends CrudRepository<VoteOptionCommentDto, Long> {
+
+    List<VoteOptionCommentDto> findAllByCategory(Category category);
+}

--- a/src/main/java/com/capstone/pick/security/VotePrincipal.java
+++ b/src/main/java/com/capstone/pick/security/VotePrincipal.java
@@ -2,6 +2,8 @@ package com.capstone.pick.security;
 
 import com.capstone.pick.config.OAuthAttributes;
 import com.capstone.pick.dto.UserDto;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,6 +18,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class VotePrincipal implements OAuth2User,UserDetails {
 
     private String username;
@@ -75,26 +78,31 @@ public class VotePrincipal implements OAuth2User,UserDetails {
     }
 
     @Override
+    @JsonIgnore
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singleton((GrantedAuthority) () -> authority);
     }
 
     @Override
+    @JsonIgnore
     public boolean isAccountNonExpired() {
         return true;
     }
 
     @Override
+    @JsonIgnore
     public boolean isAccountNonLocked() {
         return true;
     }
 
     @Override
+    @JsonIgnore
     public boolean isCredentialsNonExpired() {
         return true;
     }
 
     @Override
+    @JsonIgnore
     public boolean isEnabled() {
         return true;
     }

--- a/src/test/java/com/capstone/pick/config/TestSecurityConfig.java
+++ b/src/test/java/com/capstone/pick/config/TestSecurityConfig.java
@@ -1,6 +1,7 @@
 package com.capstone.pick.config;
 
 import com.capstone.pick.domain.User;
+import com.capstone.pick.repository.UserCacheRepository;
 import com.capstone.pick.repository.UserRepository;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -14,6 +15,8 @@ public class TestSecurityConfig {
 
     @MockBean
     private UserRepository userRepository;
+    @MockBean
+    UserCacheRepository userCacheRepository;
 
     @BeforeTestMethod
     public void securitySetUp() {

--- a/src/test/java/com/capstone/pick/service/VoteServiceTest.java
+++ b/src/test/java/com/capstone/pick/service/VoteServiceTest.java
@@ -49,6 +49,8 @@ public class VoteServiceTest {
     private HashtagRepository hashtagRepository;
     @Mock
     private VoteHashtagRepository voteHashtagRepository;
+    @Mock
+    private VoteRedisRepository voteRedisRepository;
 
     @DisplayName("타임라인을 조회하면, 모든 투표 게시글을 타임라인에 반환한다.")
     @Test


### PR DESCRIPTION
기존 우리 프로젝트에서는 처음 로그인 시에 유저 정보를 조회하고, 이후에 인증이 필요한 과정에서
계속해서 유저 정보를 DB에 조회를 했다.
이를 해결하기 위해서 로그인 시에 로그인 한 유저의 정보를 Redis에 캐시로 저장으로 함으로써
우리 프로젝트 같은 SNS에서는 한 번 로그인하면 로그아웃을 잘하지 않는 특성을 이용하여 Redis 캐시에 저장되어 있는
유저 정보로 인증을 하여 DB 접근없이 인증할 수 있도록 성능을 개선하였다.

추가적으로 현재 우리 프로젝트에서 가장 많은 부하가 발생하는 부분은 타임라인 파트이다.
타임라인의 경우 투표 게시글과 함께 작성자, 투표 선택지, 관련 댓글, 투표 참여에 대한 정보까지 함께 전달이 되기 때문에
성능 개선이 필수적이었다.
이에 따라서 타임라인에 경우는 조회시에 redis 캐시 DB에서 확인을 한 후에 조회하도록 하였다.
타임라인에 대한 캐싱과 관련된 로직은 회의를 통해서 추가적으로 결정하고, 다시 수정을 진행하여야 한다.

This closes #79 